### PR TITLE
Document `test` script's arg passing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Cleans, builds, and starts your Node project with debugging enabled. Targets the
 
 Essentially the same as `start` except your project will re-build/start when changes are seen in your `outDir`. Semi-customizable with args.
 
+### `test`
+
+Run your project's Jest tests. Passes CLI args transparently to Jest (e.g., to run just one test suite, do `npm run test testName.test.ts`).
+
 ## Project requirements
 
 ### `tsconfig.json`


### PR DESCRIPTION
I spent a minute reading code to figure out that it worked this way.

I figured I'd add a quick summary so the next newbie can skip that step.